### PR TITLE
Add const modifier to usraddr param.

### DIFF
--- a/include/rpimemmgr.h
+++ b/include/rpimemmgr.h
@@ -57,7 +57,7 @@
             const size_t block_count, const size_t block_size,
             const size_t stride);
 
-    uint32_t rpimemmgr_usraddr_to_busaddr(void * const usraddr,
+    uint32_t rpimemmgr_usraddr_to_busaddr(const void * const usraddr,
             struct rpimemmgr *sp);
 
     void unif_set_uint(uint32_t *p, const uint32_t u);


### PR DESCRIPTION
There is no need for this library itself to edit usraddr referencing area. For safe programming, `const` modifier is expected.

To remove variable global value `usraddr_to_find` used by `twalk`, I implement redundant (busaddr based and usraddr based) memory element node management. `rpimemmgr_usraddr_to_busaddr` doesn't know busaddr, so usraddr based `tfind` is required.