### PR TITLE
Support for shared CMA of VCSM

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,7 +7,7 @@ trim_trailing_whitespace = true
 insert_final_newline = true
 max_line_length=80
 
-[*.{c,h}]
+[*.{c,h,h.in}]
 indent_style = space
 indent_size = 4
 

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -1,1 +1,5 @@
-install(FILES rpimemmgr.h DESTINATION include)
+include(CheckLibraryExists)
+check_library_exists(vcsm vcsm_init_ex "${VCSM_LIBDIR}" RPIMEMMGR_VCSM_HAS_CMA)
+configure_file(rpimemmgr.h.in "${CMAKE_CURRENT_BINARY_DIR}/rpimemmgr.h" @ONLY)
+
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/rpimemmgr.h" DESTINATION include)

--- a/include/rpimemmgr.h.in
+++ b/include/rpimemmgr.h.in
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Idein Inc. ( http://idein.jp/ )
+ * Copyright (c) 2018,2019 Idein Inc. ( http://idein.jp/ )
  * All rights reserved.
  *
  * This software is licensed under a Modified (3-Clause) BSD License.
@@ -14,8 +14,13 @@
 #include <mailbox.h>
 #include <sys/types.h>
 
+#cmakedefine RPIMEMMGR_VCSM_HAS_CMA
+
     struct rpimemmgr {
         struct rpimemmgr_priv *priv;
+#ifdef RPIMEMMGR_VCSM_HAS_CMA
+        _Bool vcsm_use_cma;
+#endif /* RPIMEMMGR_VCSM_HAS_CMA */
     };
 
     enum rpimemmgr_cache_op {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -W -Wall -Wextra -pipe -O2 -g \
                    ${VCSM_CFLAGS} ${MAILBOX_CFLAGS}")
-include_directories(${CMAKE_SOURCE_DIR}/include)
+include_directories(BEFORE "${CMAKE_SOURCE_DIR}/include"
+                           "${CMAKE_CURRENT_BINARY_DIR}/../include")
 
 set(rpimemmgr_SOURCES rpimemmgr.c vcsm.c mailbox.c cache.c unif.c)
 add_library(rpimemmgr        SHARED ${rpimemmgr_SOURCES})

--- a/src/rpimemmgr.c
+++ b/src/rpimemmgr.c
@@ -178,6 +178,9 @@ int rpimemmgr_init(struct rpimemmgr *sp)
     priv->busaddr_based_root = NULL;
     priv->usraddr_based_root = NULL;
     sp->priv = priv;
+#ifdef RPIMEMMGR_VCSM_HAS_CMA
+    sp->vcsm_use_cma = 0;
+#endif /* RPIMEMMGR_VCSM_HAS_CMA */
     return 0;
 }
 
@@ -235,7 +238,11 @@ int rpimemmgr_alloc_vcsm(const size_t size, const size_t align,
     }
 
     if (!sp->priv->is_vcsm_inited) {
+#ifdef RPIMEMMGR_VCSM_HAS_CMA
+        err = vcsm_init_ex(sp->vcsm_use_cma, -1);
+#else
         err = vcsm_init();
+#endif /* RPIMEMMGR_VCSM_HAS_CMA */
         if (err) {
             print_error("Failed to initialize VCSM\n");
             return err;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,7 +6,8 @@ set(RPIMEMMGR_LDFLAGS "${BCM_HOST_LDFLAGS}" "${VCSM_LDFLAGS}"
                       "${MAILBOX_LDFLAGS}")
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -pipe -W -Wall -Wextra -O2 -g")
-include_directories("${CMAKE_SOURCE_DIR}/include")
+include_directories(BEFORE "${CMAKE_SOURCE_DIR}/include"
+                           "${CMAKE_CURRENT_BINARY_DIR}/../include")
 
 add_executable(speed speed.c)
 target_include_directories(speed PRIVATE "${RPIMEMMGR_INCLUDE_DIRS}")

--- a/test/addr.c
+++ b/test/addr.c
@@ -15,76 +15,139 @@
 #include <sys/types.h>
 #include <inttypes.h>
 
-static int test_vcsm(const VCSM_CACHE_TYPE_T cache_type, struct rpimemmgr *sp)
+static int test_vcsm_gpu(const VCSM_CACHE_TYPE_T cache_type)
 {
     uint32_t busaddr;
     int err;
-
-    err = rpimemmgr_alloc_vcsm(4096, 4096, cache_type, NULL, &busaddr, sp);
-    if (err)
-        return err;
-
-    printf("busaddr=0x%08" PRIx32 "\n", busaddr);
-
-    return rpimemmgr_free_by_busaddr(busaddr, sp);
-}
-
-static int test_mailbox(const uint32_t flags, struct rpimemmgr *sp)
-{
-    uint32_t busaddr;
-    int err;
-
-    err = rpimemmgr_alloc_mailbox(4096, 4096, flags, NULL, &busaddr, sp);
-    if (err)
-        return err;
-
-    printf("busaddr=0x%08" PRIx32 "\n", busaddr);
-
-    return rpimemmgr_free_by_busaddr(busaddr, sp);
-}
-
-int main(void)
-{
     struct rpimemmgr st;
-    int err;
 
     err = rpimemmgr_init(&st);
     if (err)
         return err;
 
-    printf("VCSM:    NONE:             ");
-    err = test_vcsm(VCSM_CACHE_TYPE_NONE,        &st);
-    if (err)
-        return err;
-    printf("VCSM:    HOST:             ");
-    err = test_vcsm(VCSM_CACHE_TYPE_HOST,        &st);
-    if (err)
-        return err;
-    printf("VCSM:    VC:               ");
-    err = test_vcsm(VCSM_CACHE_TYPE_VC,          &st);
-    if (err)
-        return err;
-    printf("VCSM:    HOST_AND_VC:      ");
-    err = test_vcsm(VCSM_CACHE_TYPE_HOST_AND_VC, &st);
+    err = rpimemmgr_alloc_vcsm(4096, 4096, cache_type, NULL, &busaddr, &st);
     if (err)
         return err;
 
-    printf("Mailbox: NORMAL:           ");
-    err = test_mailbox(MEM_FLAG_NORMAL,           &st);
-    if (err)
-        return err;
-    printf("Mailbox: DIRECT:           ");
-    err = test_mailbox(MEM_FLAG_DIRECT,           &st);
-    if (err)
-        return err;
-    printf("Mailbox: COHERENT:         ");
-    err = test_mailbox(MEM_FLAG_COHERENT,         &st);
-    if (err)
-        return err;
-    printf("Mailbox: L1_NONALLOCATING: ");
-    err = test_mailbox(MEM_FLAG_L1_NONALLOCATING, &st);
+    printf("busaddr=0x%08" PRIx32 "\n", busaddr);
+
+    err = rpimemmgr_free_by_busaddr(busaddr, &st);
     if (err)
         return err;
 
     return rpimemmgr_finalize(&st);
+}
+
+#ifdef RPIMEMMGR_VCSM_HAS_CMA
+
+static int test_vcsm_cma(const VCSM_CACHE_TYPE_T cache_type)
+{
+    uint32_t busaddr;
+    int err;
+    struct rpimemmgr st;
+
+    err = rpimemmgr_init(&st);
+    if (err)
+        return err;
+
+    st.vcsm_use_cma = 1;
+
+    err = rpimemmgr_alloc_vcsm(4096, 4096, cache_type, NULL, &busaddr, &st);
+    if (err)
+        return err;
+
+    printf("busaddr=0x%08" PRIx32 "\n", busaddr);
+
+    err = rpimemmgr_free_by_busaddr(busaddr, &st);
+    if (err)
+        return err;
+
+    return rpimemmgr_finalize(&st);
+}
+
+#endif /* RPIMEMMGR_VCSM_HAS_CMA */
+
+static int test_mailbox(const uint32_t flags)
+{
+    uint32_t busaddr;
+    int err;
+    struct rpimemmgr st;
+
+    err = rpimemmgr_init(&st);
+    if (err)
+        return err;
+
+    err = rpimemmgr_alloc_mailbox(4096, 4096, flags, NULL, &busaddr, &st);
+    if (err)
+        return err;
+
+    printf("busaddr=0x%08" PRIx32 "\n", busaddr);
+
+    err = rpimemmgr_free_by_busaddr(busaddr, &st);
+    if (err)
+        return err;
+
+    return rpimemmgr_finalize(&st);
+}
+
+int main(void)
+{
+    int err;
+
+    printf("VCSM (GPU):    NONE:             ");
+    err = test_vcsm_gpu(VCSM_CACHE_TYPE_NONE);
+    if (err)
+        return err;
+    printf("VCSM (GPU):    HOST:             ");
+    err = test_vcsm_gpu(VCSM_CACHE_TYPE_HOST);
+    if (err)
+        return err;
+    printf("VCSM (GPU):    VC:               ");
+    err = test_vcsm_gpu(VCSM_CACHE_TYPE_VC);
+    if (err)
+        return err;
+    printf("VCSM (GPU):    HOST_AND_VC:      ");
+    err = test_vcsm_gpu(VCSM_CACHE_TYPE_HOST_AND_VC);
+    if (err)
+        return err;
+
+#ifdef RPIMEMMGR_VCSM_HAS_CMA
+
+    printf("VCSM (CMA):    NONE:             ");
+    err = test_vcsm_cma(VCSM_CACHE_TYPE_NONE);
+    if (err)
+        return err;
+    printf("VCSM (CMA):    HOST:             ");
+    err = test_vcsm_cma(VCSM_CACHE_TYPE_HOST);
+    if (err)
+        return err;
+    printf("VCSM (CMA):    VC:               ");
+    err = test_vcsm_cma(VCSM_CACHE_TYPE_VC);
+    if (err)
+        return err;
+    printf("VCSM (CMA):    HOST_AND_VC:      ");
+    err = test_vcsm_cma(VCSM_CACHE_TYPE_HOST_AND_VC);
+    if (err)
+        return err;
+
+#endif /* RPIMEMMGR_VCSM_HAS_CMA */
+
+    printf("Mailbox: NORMAL:           ");
+    err = test_mailbox(MEM_FLAG_NORMAL);
+    if (err)
+        return err;
+    printf("Mailbox: DIRECT:           ");
+    err = test_mailbox(MEM_FLAG_DIRECT);
+    if (err)
+        return err;
+    printf("Mailbox: COHERENT:         ");
+    err = test_mailbox(MEM_FLAG_COHERENT);
+    if (err)
+        return err;
+    printf("Mailbox: L1_NONALLOCATING: ");
+    err = test_mailbox(MEM_FLAG_L1_NONALLOCATING);
+    if (err)
+        return err;
+
+    return 0;
 }


### PR DESCRIPTION
VCSM started to support shared CMA between ARM and VPU in https://github.com/raspberrypi/userland/commit/336c8c3d1e97fc7d0a96d5e420afa0f55c56ab1c , which enables less memory usage.  This PR enables the shared CMA by calling the new init function `vcsm_init_ex` instead of `vcsm_init`.

However, because `vcsm_vc_addr_from_hdl` (VCSM handle to bus address conversion function) is not implemented for now https://github.com/raspberrypi/userland/commit/336c8c3d1e97fc7d0a96d5e420afa0f55c56ab1c#diff-da7e45f5ac19cdc710c1dfdb731d8cdeL727-L734 , we will wait for it until it is implemented.